### PR TITLE
Update CareerBuilder API version from 1 to 2

### DIFF
--- a/src/Queries/CareerbuilderQuery.php
+++ b/src/Queries/CareerbuilderQuery.php
@@ -485,7 +485,7 @@ class CareerbuilderQuery extends AbstractQuery
      */
     public function getBaseUrl()
     {
-        return 'http://api.careerbuilder.com/v1/jobsearch';
+        return 'http://api.careerbuilder.com/v2/jobsearch';
     }
 
     /**

--- a/tests/src/CareerbuilderQueryTest.php
+++ b/tests/src/CareerbuilderQueryTest.php
@@ -20,7 +20,7 @@ class CareerbuilderQueryTest extends \PHPUnit_Framework_TestCase
     public function testItCanGetBaseUrl()
     {
         $this->assertEquals(
-            'http://api.careerbuilder.com/v1/jobsearch',
+            'http://api.careerbuilder.com/v2/jobsearch',
             $this->query->getBaseUrl()
         );
     }


### PR DESCRIPTION
Version 3 of the CareerBuilder API is being rolled out right now in internal CareerBuilder projects, so it's safe to assume v1 will be deprecated soon. Since there are no documented differences between v1 and v2 of the Job APIs, this commit updates the CB API endpoint from v1 to v2.
